### PR TITLE
Allow issue_authority to be the freeze_authority

### DIFF
--- a/programs/crate-token/src/account_validators.rs
+++ b/programs/crate-token/src/account_validators.rs
@@ -14,11 +14,14 @@ impl<'info> Validate<'info> for NewCrate<'info> {
             self.crate_token,
             "crate_mint.mint_authority"
         );
-        assert_keys_eq!(
-            self.crate_mint.freeze_authority.unwrap(),
-            self.crate_token,
-            "crate_mint.mint_authority"
+
+        let freeze_authority = self.crate_mint.freeze_authority.unwrap();
+        invariant!(
+            freeze_authority == self.crate_token.key()
+                || freeze_authority == self.issue_authority.key(),
+            InvalidFreezeAuthority
         );
+
         invariant!(self.crate_mint.supply == 0, "supply must be zero");
         Ok(())
     }

--- a/programs/crate-token/src/lib.rs
+++ b/programs/crate-token/src/lib.rs
@@ -393,6 +393,8 @@ pub struct Withdraw<'info> {
 pub enum ErrorCode {
     #[msg("Maximum fee exceeded.")]
     MaxFeeExceeded,
+    #[msg("Freeze authority must either be the issuer or the Crate itself.")]
+    InvalidFreezeAuthority,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
We would like access to the `freeze_authority` to ensure that Venko streams are non-transferrable.